### PR TITLE
Fix 11ty link in footer not working

### DIFF
--- a/src/_includes/footer.njk
+++ b/src/_includes/footer.njk
@@ -6,7 +6,7 @@
 		</div>
 		<div class="footer__column">
 			<small>
-				{{ "developed" | translate }} <a href="{{ links.public.eleventy }}">11ty</a>, {{ "icons from" | translate }} <a href="{{ links.copyright.lucide }}">Lucide</a>
+				{{ "developed" | translate }} <a href="{{ links.copyright.eleventy }}">11ty</a>, {{ "icons from" | translate }} <a href="{{ links.copyright.lucide }}">Lucide</a>
 			</small>
 			<small>
 				{{ "github repo" | translate }} <a href="{{ links.public.github }}">GitHub</a>


### PR DESCRIPTION
Hello !
Thank you for the great articles you've made!

I've stumbled upon this really small bug, nothing groundbreaking :)

## Bug

The 11ty link on the footer has no href. 

https://github.com/user-attachments/assets/94db488c-147d-444a-8c72-5f2c83d49086

## Fix

- Use the correct variable for the link.