### PR TITLE
Fix a typo in the heading

### DIFF
--- a/src/_data/i18n/index.yaml
+++ b/src/_data/i18n/index.yaml
@@ -2,5 +2,5 @@ ru:
   latest (heading): "Недавние статьи"
   all articles (link): "Все статьи"
 en:
-  latest (heading): "Resent articles"
+  latest (heading): "Recent articles"
   all articles (link): "All articles"


### PR DESCRIPTION
Hi Tatiana! I was reading your blog (great articles, by the way, thank you for writing them!) and encountered a typo in the English version:
<img width="858" alt="image" src="https://github.com/user-attachments/assets/d3931131-d523-46e9-b087-76bd7bac69e5">


"Resent" is a verb that means "dislike", "distance yourself from". "Recent" is likely what was originally intended :)